### PR TITLE
Use Sword class as a parent class to avoid code duplications

### DIFF
--- a/assets/spriteSheets/spriteSheet.json
+++ b/assets/spriteSheets/spriteSheet.json
@@ -24,7 +24,7 @@
                 "to": 19
             }
         },
-        "sword": {
+        "stoneSword": {
             "frame": 37
         },
         "forrestSword": {

--- a/assets/tileMaps/tileMap01.json
+++ b/assets/tileMaps/tileMap01.json
@@ -203,7 +203,7 @@
                  "gid":38,
                  "height":16,
                  "id":53,
-                 "name":"sword",
+                 "name":"stoneSword",
                  "rotation":0,
                  "type":"",
                  "visible":true,

--- a/src/entities/swords/forrestSword.ts
+++ b/src/entities/swords/forrestSword.ts
@@ -1,29 +1,10 @@
 import spriteSheetConfig from "../../../assets/spriteSheets/spriteSheet.json";
+import Sword from './sword'
 
-export default class ForrestSword extends Phaser.Physics.Arcade.Sprite {
-
-    hitPower = 2;
-
+export default class ForrestSword extends Sword {
     constructor(scene: Phaser.Scene, x, y, key) {
-        super(scene, x, y, key, spriteSheetConfig.content.forrestSword.frame);
+        super(scene, x, y, key, spriteSheetConfig.content.forrestSword.frame, 2);
         this.scene.add.existing(this);
         this.setOrigin(0, 1);
-    }
-
-    setFlipX(value) {
-        this.setDirectionOrigin(value);
-        return super.setFlipX(value);
-    }
-
-    setDirectionOrigin(leftDirection) {
-        if (leftDirection) {
-            this.setOrigin(1, 1);
-        } else {
-            this.setOrigin(0, 1);
-        }
-    }
-
-    setAngle(value) {
-        return super.setAngle(this.flipX ? - value : value);
     }
 }

--- a/src/entities/swords/stoneSword.ts
+++ b/src/entities/swords/stoneSword.ts
@@ -1,8 +1,8 @@
 import spriteSheetConfig from "../../../assets/spriteSheets/spriteSheet.json";
 import Sword from './sword'
 
-export default class HellSword extends Sword {
+export default class StoneSword extends Sword {
     constructor(scene: Phaser.Scene, x, y, key) {
-        super(scene, x, y, key, spriteSheetConfig.content.hellSword.frame, 3);
+        super(scene, x, y, key, spriteSheetConfig.content.stoneSword.frame, 1);
     }
 }

--- a/src/entities/swords/sword.ts
+++ b/src/entities/swords/sword.ts
@@ -2,10 +2,11 @@ import spriteSheetConfig from "../../../assets/spriteSheets/spriteSheet.json";
 
 export default class Sword extends Phaser.Physics.Arcade.Sprite {
 
-    hitPower = 1;
+    hitPower = null;
 
-    constructor(scene: Phaser.Scene, x, y, key) {
-        super(scene, x, y, key, spriteSheetConfig.content.sword.frame);
+    constructor(scene: Phaser.Scene, x, y, key, sprite: number, hitPower: number) {
+        super(scene, x, y, key, sprite);
+        this.hitPower = hitPower;
         this.scene.add.existing(this);
         this.setOrigin(0, 1);
     }

--- a/src/scenes/mainScene.ts
+++ b/src/scenes/mainScene.ts
@@ -12,6 +12,7 @@ import SwordPickUp from "../entities/swords/swordPickUp";
 import Sword from "../entities/swords/sword";
 import ForrestSword from "../entities/swords/forrestSword";
 import HellSword from "../entities/swords/hellSword";
+import StoneSword from "../entities/swords/stoneSword";
 import PlayerCommands from "../entities/player/playerCommands.js";
 
 export default class MainScene extends Phaser.Scene {
@@ -76,12 +77,12 @@ export default class MainScene extends Phaser.Scene {
         // Pickup management
         this.pickupGroup = this.add.group();
         this.pickupGroup.addMultiple((new GemFactory(this, spriteSheetConfig.name)).generateGemsFromMap(this.map));
-        const sword: any = this.map.findObject("weapons", obj => obj.name === "sword");
+        const stoneSword: any = this.map.findObject("weapons", obj => obj.name === "stoneSword");
         const forrestSword: any = this.map.findObject("weapons", obj => obj.name === "forrestSword");
         const hellSword: any = this.map.findObject("weapons", obj => obj.name === "hellSword");
         this.pickupGroup.addMultiple([
-            new SwordPickUp(this, sword.x + 8, sword.y - 8, spriteSheetConfig.name,
-                spriteSheetConfig.content.sword.frame, Sword),
+            new SwordPickUp(this, stoneSword.x + 8, stoneSword.y - 8, spriteSheetConfig.name,
+                spriteSheetConfig.content.stoneSword.frame, StoneSword),
             new SwordPickUp(this, forrestSword.x + 8, forrestSword.y - 8, spriteSheetConfig.name,
                 spriteSheetConfig.content.forrestSword.frame, ForrestSword),
             new SwordPickUp(this, hellSword.x + 8, hellSword.y - 8, spriteSheetConfig.name,


### PR DESCRIPTION
Sword class was duplicated in the others sword class.
Use Sword class as a parent class and extends specific swords from it